### PR TITLE
Add type conversion from &str to Selector

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,5 +1,6 @@
 //! CSS selectors.
 
+use std::convert::TryFrom;
 use std::fmt;
 
 use smallvec::SmallVec;
@@ -127,5 +128,35 @@ impl cssparser::ToCss for PseudoElement {
         W: fmt::Write,
     {
         dest.write_str("")
+    }
+}
+
+impl<'i> TryFrom<&'i str> for Selector {
+    type Error = cssparser::ParseError<'i, SelectorParseErrorKind<'i>>;
+
+    fn try_from(s: &'i str) -> Result<Self, Self::Error> {
+        Selector::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryInto;
+
+    #[test]
+    fn selector_conversions() {
+        let s = "#testid.testclass";
+        let _sel: Selector = s.try_into().unwrap();
+
+        let s = s.to_owned();
+        let _sel: Selector = (*s).try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_selector_conversions() {
+        let s = "<failing selector>";
+        let _sel: Selector = s.try_into().unwrap();
     }
 }


### PR DESCRIPTION
Implement `TryFrom<&str>` for `Selector`. 

This gives us the `try_from` method as well as the `try_into` method. Both return a result type the same as that in `Selector::parse`. Tests added to validate functionality and syntax.

See issue #27 for more background.
See pull request #30 for other work on the syntax but on the `select` method instead.