### PR TITLE
docs: add notice for deterministic attribute (de)serialization

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -229,6 +229,8 @@ impl fmt::Debug for Text {
 pub type Attributes = indexmap::IndexMap<QualName, StrTendril>;
 
 /// A Map of attributes that doesn't preserve the order of the attributes.
+/// Please enable the `deterministic` feature for order-preserving
+/// (de)serialization.
 #[cfg(not(feature = "deterministic"))]
 pub type Attributes = HashMap<QualName, StrTendril>;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -229,6 +229,7 @@ impl fmt::Debug for Text {
 pub type Attributes = indexmap::IndexMap<QualName, StrTendril>;
 
 /// A Map of attributes that doesn't preserve the order of the attributes.
+/// 
 /// Please enable the `deterministic` feature for order-preserving
 /// (de)serialization.
 #[cfg(not(feature = "deterministic"))]


### PR DESCRIPTION
I just noticed that there isn't really a documentation that states that the feature exists. Is there another place where we should mention the feature? It's not _that_ visible right now on the `Attribute` documentation.

@teymour-aldridge 