### PR TITLE
Re-export CaseSensitivity to easily specify the has_class argument case_sensitive

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use html5ever::tendril::StrTendril;
 use html5ever::{Attribute, LocalName, QualName};
 
-use selectors::attr::CaseSensitivity;
+pub use selectors::attr::CaseSensitivity;
 
 /// An HTML node.
 #[derive(Clone, PartialEq, Eq)]


### PR DESCRIPTION
[`scraper::node::Element::has_class`](https://docs.rs/scraper/0.12.0/scraper/node/struct.Element.html#method.has_class) requires `selectors::attr::CaseSensitivity` as an argument, but this type is not exposed.