### PR TITLE
refactor: Make Selector's field private

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -17,7 +17,7 @@ use crate::ElementRef;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Selector {
     /// The CSS selectors.
-    pub selectors: SmallVec<[parser::Selector<Simple>; 1]>,
+    selectors: SmallVec<[parser::Selector<Simple>; 1]>,
 }
 
 impl Selector {


### PR DESCRIPTION
A little pet peeve I came across when using this library (it's awesome btw!) was rust-analyzer suggesting often times the initialisation of the `Selector` struct manually since the `selectors` field is public. This PR changes the visibility from
```Rust
pub struct Selector {
    pub selectors: SmallVec<[parser::Selector<Simple>; 1]>,
}
```
to 
```Rust
pub struct Selector {
    selectors: SmallVec<[parser::Selector<Simple>; 1]>,
}
```
No breaking changes are introduced as the `selectors` field isn't used directly anywhere outside the module anyways.