### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ selectors = "0.22.0"
 smallvec = "1.9.0"
 tendril = "0.4.3"
 indexmap = { version = "1.9.1", optional = true }
+fnv = "1.0.7"
 
 [dependencies.getopts]
 version = "0.2.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ selectors = "0.22.0"
 smallvec = "1.9.0"
 tendril = "0.4.3"
 indexmap = { version = "1.9.1", optional = true }
-fnv = "1.0.7"
+ahash = "0.8"
 
 [dependencies.getopts]
 version = "0.2.21"

--- a/src/element_ref/element.rs
+++ b/src/element_ref/element.rs
@@ -30,22 +30,6 @@ impl<'a> Element for ElementRef<'a> {
         false
     }
 
-    fn is_part(&self, _name: &LocalName) -> bool {
-        false
-    }
-
-    fn is_same_type(&self, other: &Self) -> bool {
-        self.value().name == other.value().name
-    }
-
-    fn exported_part(&self, _: &LocalName) -> Option<LocalName> {
-        None
-    }
-
-    fn imported_part(&self, _: &LocalName) -> Option<LocalName> {
-        None
-    }
-
     fn prev_sibling_element(&self) -> Option<Self> {
         self.prev_siblings()
             .find(|sibling| sibling.value().is_element())
@@ -69,6 +53,10 @@ impl<'a> Element for ElementRef<'a> {
 
     fn has_namespace(&self, namespace: &Namespace) -> bool {
         &self.value().name.ns == namespace
+    }
+
+    fn is_same_type(&self, other: &Self) -> bool {
+        self.value().name == other.value().name
     }
 
     fn attr_matches(
@@ -118,6 +106,18 @@ impl<'a> Element for ElementRef<'a> {
 
     fn has_class(&self, name: &LocalName, case_sensitivity: CaseSensitivity) -> bool {
         self.value().has_class(name, case_sensitivity)
+    }
+
+    fn exported_part(&self, _: &LocalName) -> Option<LocalName> {
+        None
+    }
+
+    fn imported_part(&self, _: &LocalName) -> Option<LocalName> {
+        None
+    }
+
+    fn is_part(&self, _name: &LocalName) -> bool {
+        false
     }
 
     fn is_empty(&self) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,5 +129,5 @@ fn main() {
             .any(|m| m)
     };
 
-    process::exit(if matched { 0 } else { 1 });
+    process::exit(i32::from(!matched));
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,6 @@
 //! HTML nodes.
 
-use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
+use ahash::{HashMap, HashSet};
 use std::collections::{hash_map, hash_set};
 use std::fmt;
 use std::ops::Deref;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 //! HTML nodes.
 
+use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use std::collections::{hash_map, hash_set};
-use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::ops::Deref;
 
@@ -223,10 +223,10 @@ pub struct Element {
     pub name: QualName,
 
     /// The element ID.
-    pub id: Option<LocalName>,
+    pub id: Option<String>,
 
     /// The element classes.
-    pub classes: HashSet<LocalName>,
+    pub classes: HashSet<String>,
 
     /// The element attributes.
     pub attrs: Attributes,
@@ -238,16 +238,16 @@ impl Element {
         let id = attrs
             .iter()
             .find(|a| a.name.local.deref() == "id")
-            .map(|a| LocalName::from(a.value.deref()));
+            .map(|a| String::from(a.value.deref()));
 
-        let classes: HashSet<LocalName> = attrs
+        let classes: HashSet<String> = attrs
             .iter()
             .find(|a| a.name.local.deref() == "class")
-            .map_or(HashSet::new(), |a| {
+            .map_or(HashSet::default(), |a| {
                 a.value
                     .deref()
                     .split_whitespace()
-                    .map(LocalName::from)
+                    .map(String::from)
                     .collect()
             });
 
@@ -300,7 +300,7 @@ impl Element {
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
 pub struct Classes<'a> {
-    inner: hash_set::Iter<'a, LocalName>,
+    inner: hash_set::Iter<'a, String>,
 }
 
 impl<'a> Iterator for Classes<'a> {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -65,21 +65,21 @@ impl<'i> parser::Parser<'i> for Parser {
 pub struct Simple;
 
 impl parser::SelectorImpl for Simple {
+    // see: https://github.com/servo/servo/pull/19747#issuecomment-357106065
+    type ExtraMatchingData = String;
     type AttrValue = String;
     type Identifier = LocalName;
     type ClassName = LocalName;
     type PartName = LocalName;
     type LocalName = LocalName;
-    type NamespacePrefix = LocalName;
     type NamespaceUrl = Namespace;
+    type NamespacePrefix = LocalName;
     type BorrowedNamespaceUrl = Namespace;
+
     type BorrowedLocalName = LocalName;
-
     type NonTSPseudoClass = NonTSPseudoClass;
-    type PseudoElement = PseudoElement;
 
-    // see: https://github.com/servo/servo/pull/19747#issuecomment-357106065
-    type ExtraMatchingData = String;
+    type PseudoElement = PseudoElement;
 }
 
 /// Non Tree-Structural Pseudo-Class.


### PR DESCRIPTION
I have tried to improve parsing performance by replacing the standard hash function with fnv and by replacing LocalNames with strings (in node.rs) as suggested in #45.
@teymour-aldridge are there any other changes we could make to improve parsing speed? Could someone that needs to parse multiple/huge HTMLs perform some benchmarks and report back?