### PR TITLE
An Error Type for `Selector::parse`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,65 @@
+//! Custom error types for diagnostics
+//! Includes re-exported error types from dependencies
+
+use std::fmt::Display;
+
+use cssparser::{BasicParseErrorKind, ParseErrorKind, Token};
+use selectors::parser::SelectorParseErrorKind;
+
+/// Error type that is returned when calling `Selector::parse`
+#[derive(Debug, Clone)]
+pub enum SelectorErrorKind<'a> {
+    /// A `Token` was not expected
+    UnexpectedToken(Token<'a>),
+
+    /// End-Of-Line was unexpected
+    EndOfLine,
+
+    /// `@` rule is invalid
+    InvalidAtRule(String),
+
+    /// The body of an `@` rule is invalid
+    InvalidAtRuleBody,
+
+    /// The qualified rule is invalid
+    QualRuleInvalid,
+
+    /// Expected a `::` for a pseudoelement
+    ExpectedColonOnPseudoElement(Token<'a>),
+
+    /// Expected an identity for a pseudoelement
+    ExpectedIdentityOnPseudoElement(Token<'a>),
+
+    /// A `SelectorParseErrorKind` error that isn't really supposed to happen did
+    UnexpectedSelectorParseError(SelectorParseErrorKind<'a>),
+}
+
+impl<'a> From<cssparser::ParseError<'a, SelectorParseErrorKind<'a>>> for SelectorErrorKind<'a> {
+    fn from(original: cssparser::ParseError<'a, SelectorParseErrorKind<'a>>) -> Self {
+        // To anyone who dares to read this code
+        // I commend you, i guess. I'm so sorry
+        // for the abomination that is casting
+        // stuff into this one enum
+
+        match original.kind {
+            ParseErrorKind::Basic(err) => match err {
+                BasicParseErrorKind::UnexpectedToken(token) => Self::UnexpectedToken(token),
+                BasicParseErrorKind::EndOfInput => Self::EndOfLine,
+                BasicParseErrorKind::AtRuleInvalid(rule) => {
+                    Self::InvalidAtRule(rule.clone().to_string())
+                }
+                BasicParseErrorKind::AtRuleBodyInvalid => Self::InvalidAtRuleBody,
+                BasicParseErrorKind::QualifiedRuleInvalid => Self::QualRuleInvalid,
+            },
+            ParseErrorKind::Custom(err) => match err {
+                SelectorParseErrorKind::PseudoElementExpectedColon(token) => {
+                    Self::ExpectedColonOnPseudoElement(token)
+                }
+                SelectorParseErrorKind::PseudoElementExpectedIdent(token) => {
+                    Self::ExpectedIdentityOnPseudoElement(token)
+                }
+                other => Self::UnexpectedSelectorParseError(other),
+            },
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,10 +84,10 @@ impl<'a> Display for SelectorErrorKind<'a> {
                 Self::UnexpectedToken(token) => {
                     format!("Token {:?} was not expected", utils::render_token(token))
                 }
-                Self::EndOfLine => format!("Unexpected EOL"),
+                Self::EndOfLine => "Unexpected EOL".to_string(),
                 Self::InvalidAtRule(rule) => format!("Invalid @-rule {:?}", rule),
-                Self::InvalidAtRuleBody => format!("The body of an @-rule was invalid"),
-                Self::QualRuleInvalid => format!("The qualified name was invalid"),
+                Self::InvalidAtRuleBody => "The body of an @-rule was invalid".to_string(),
+                Self::QualRuleInvalid => "The qualified name was invalid".to_string(),
                 Self::ExpectedColonOnPseudoElement(token) => format!(
                     "Expected a ':' token for pseudoelement, got {:?} instead",
                     utils::render_token(token)

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,30 +38,39 @@ pub enum SelectorErrorKind<'a> {
 
 impl<'a> From<cssparser::ParseError<'a, SelectorParseErrorKind<'a>>> for SelectorErrorKind<'a> {
     fn from(original: cssparser::ParseError<'a, SelectorParseErrorKind<'a>>) -> Self {
-        // To anyone who dares to read this code
-        // I commend you, i guess. I'm so sorry
-        // for the abomination that is casting
-        // stuff into this one enum
-
+        // NOTE: This could be improved, but I dont
+        // exactly know how
         match original.kind {
-            ParseErrorKind::Basic(err) => match err {
-                BasicParseErrorKind::UnexpectedToken(token) => Self::UnexpectedToken(token),
-                BasicParseErrorKind::EndOfInput => Self::EndOfLine,
-                BasicParseErrorKind::AtRuleInvalid(rule) => {
-                    Self::InvalidAtRule(rule.clone().to_string())
-                }
-                BasicParseErrorKind::AtRuleBodyInvalid => Self::InvalidAtRuleBody,
-                BasicParseErrorKind::QualifiedRuleInvalid => Self::QualRuleInvalid,
-            },
-            ParseErrorKind::Custom(err) => match err {
-                SelectorParseErrorKind::PseudoElementExpectedColon(token) => {
-                    Self::ExpectedColonOnPseudoElement(token)
-                }
-                SelectorParseErrorKind::PseudoElementExpectedIdent(token) => {
-                    Self::ExpectedIdentityOnPseudoElement(token)
-                }
-                other => Self::UnexpectedSelectorParseError(other),
-            },
+            ParseErrorKind::Basic(err) => SelectorErrorKind::from(err),
+            ParseErrorKind::Custom(err) => SelectorErrorKind::from(err),
+        }
+    }
+}
+
+impl<'a> From<BasicParseErrorKind<'a>> for SelectorErrorKind<'a> {
+    fn from(err: BasicParseErrorKind<'a>) -> Self {
+        match err {
+            BasicParseErrorKind::UnexpectedToken(token) => Self::UnexpectedToken(token),
+            BasicParseErrorKind::EndOfInput => Self::EndOfLine,
+            BasicParseErrorKind::AtRuleInvalid(rule) => {
+                Self::InvalidAtRule(rule.clone().to_string())
+            }
+            BasicParseErrorKind::AtRuleBodyInvalid => Self::InvalidAtRuleBody,
+            BasicParseErrorKind::QualifiedRuleInvalid => Self::QualRuleInvalid,
+        }
+    }
+}
+
+impl<'a> From<SelectorParseErrorKind<'a>> for SelectorErrorKind<'a> {
+    fn from(err: SelectorParseErrorKind<'a>) -> Self {
+        match err {
+            SelectorParseErrorKind::PseudoElementExpectedColon(token) => {
+                Self::ExpectedColonOnPseudoElement(token)
+            }
+            SelectorParseErrorKind::PseudoElementExpectedIdent(token) => {
+                Self::ExpectedIdentityOnPseudoElement(token)
+            }
+            other => Self::UnexpectedSelectorParseError(other),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ impl<'a> Display for SelectorErrorKind<'a> {
                     utils::render_token(token)
                 ),
                 Self::UnexpectedSelectorParseError(err) => format!(
-                    "Unexpected error occurred. PLEASE REPORT THIS TO THE DEVELOPER\n{:#?}",
+                    "Unexpected error occurred. Please report this to the developer\n{:#?}",
                     err
                 ),
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,3 +65,33 @@ impl<'a> From<cssparser::ParseError<'a, SelectorParseErrorKind<'a>>> for Selecto
         }
     }
 }
+
+impl<'a> Display for SelectorErrorKind<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::UnexpectedToken(token) => {
+                    format!("Token {:?} was not expected", utils::render_token(token))
+                }
+                Self::EndOfLine => format!("Unexpected EOL"),
+                Self::InvalidAtRule(rule) => format!("Invalid @-rule {:?}", rule),
+                Self::InvalidAtRuleBody => format!("The body of an @-rule was invalid"),
+                Self::QualRuleInvalid => format!("The qualified name was invalid"),
+                Self::ExpectedColonOnPseudoElement(token) => format!(
+                    "Expected a ':' token for pseudoelement, got {:?} instead",
+                    utils::render_token(token)
+                ),
+                Self::ExpectedIdentityOnPseudoElement(token) => format!(
+                    "Expected identity for pseudoelement, got {:?} instead",
+                    utils::render_token(token)
+                ),
+                Self::UnexpectedSelectorParseError(err) => format!(
+                    "Unexpected error occurred. PLEASE REPORT THIS TO THE DEVELOPER\n{:#?}",
+                    err
+                ),
+            }
+        )
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 
 mod utils;
 
-use std::fmt::Display;
+use std::{error::Error, fmt::Display};
 
 use cssparser::{BasicParseErrorKind, ParseErrorKind, Token};
 use selectors::parser::SelectorParseErrorKind;
@@ -102,5 +102,20 @@ impl<'a> Display for SelectorErrorKind<'a> {
                 ),
             }
         )
+    }
+}
+
+impl<'a> Error for SelectorErrorKind<'a> {
+    fn description(&self) -> &str {
+        match self {
+            Self::UnexpectedToken(_) => "Token was not expected",
+            Self::EndOfLine => "Unexpected EOL",
+            Self::InvalidAtRule(_) => "Invalid @-rule",
+            Self::InvalidAtRuleBody => "The body of an @-rule was invalid",
+            Self::QualRuleInvalid => "The qualified name was invalid",
+            Self::ExpectedColonOnPseudoElement(_) => "Missing colon character on pseudoelement",
+            Self::ExpectedIdentityOnPseudoElement(_) => "Missing pseudoelement identity",
+            Self::UnexpectedSelectorParseError(_) => "Unexpected error",
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 //! Custom error types for diagnostics
 //! Includes re-exported error types from dependencies
 
+mod utils;
+
 use std::fmt::Display;
 
 use cssparser::{BasicParseErrorKind, ParseErrorKind, Token};

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -1,8 +1,7 @@
 use cssparser::Token;
 
-pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
+pub(crate) fn render_token(token: &Token<'_>) -> String {
     // THIS TOOK FOREVER TO IMPLEMENT
-    // TODO: Make this easier to read, I guess
 
     match token {
         // TODO: Give these guys some better names
@@ -19,7 +18,7 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
             has_sign: signed,
             unit_value: num,
             int_value: _,
-        } => render_number(*signed, *num, &token),
+        } => render_number(*signed, *num, token),
         Token::Dimension {
             has_sign: signed,
             value: num,
@@ -27,12 +26,12 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
             unit,
         } => format!("{}{}", render_int(*signed, *num), unit),
         Token::WhiteSpace(_) => String::from(" "),
-        Token::Comment(comment) => format!("/* {} */", comment.clone()),
+        Token::Comment(comment) => format!("/* {} */", &(*comment).clone()),
         Token::Function(name) => format!("{}()", name.clone()),
         Token::BadString(string) => format!("<Bad String {:?}>", string.clone()),
         Token::BadUrl(url) => format!("<Bad URL {:?}>", url.clone()),
         // Single-character token
-        sc_token => render_single_char_token(&sc_token),
+        sc_token => render_single_char_token(sc_token),
     }
 }
 
@@ -65,7 +64,7 @@ fn render_number(signed: bool, num: f32, token: &Token) -> String {
     let num = render_int(signed, num);
 
     match token {
-        Token::Number { .. } => format!("{}", num),
+        Token::Number { .. } => num.to_string(),
         Token::Percentage { .. } => format!("{}%", num),
         _ => panic!("render_number is not supposed to be called on a non-numerical token"),
     }

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -82,6 +82,14 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
     }
 }
 
+fn render_int(signed: bool, number: f32) -> String {
+    if signed {
+        render_int_signed(num)
+    } else {
+        render_int_unsigned(num)
+    }
+}
+
 fn render_int_signed(num: f32) -> String {
     if num > 0.0 {
         format!("+{}", num)

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -14,43 +14,18 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
             has_sign: signed,
             value: num,
             int_value: _,
-        } => {
-            if *signed {
-                render_int_signed(*num)
-            } else {
-                render_int_unsigned(*num)
-            }
         }
-        Token::Percentage {
+        | Token::Percentage {
             has_sign: signed,
             unit_value: num,
             int_value: _,
-        } => {
-            format!(
-                "{}%",
-                if *signed {
-                    render_int_signed(*num)
-                } else {
-                    render_int_unsigned(*num)
-                }
-            )
-        }
+        } => render_number(*signed, *num, &token),
         Token::Dimension {
             has_sign: signed,
             value: num,
             int_value: _,
             unit,
-        } => {
-            format!(
-                "{}{}",
-                if *signed {
-                    render_int_signed(*num)
-                } else {
-                    render_int_unsigned(*num)
-                },
-                unit
-            )
-        }
+        } => format!("{}{}", render_int(*signed, *num), unit),
         Token::WhiteSpace(_) => String::from(" "),
         Token::Comment(comment) => format!("/* {} */", comment),
         Token::Function(name) => format!("{}()", name),
@@ -82,7 +57,17 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
     }
 }
 
-fn render_int(signed: bool, number: f32) -> String {
+fn render_number(signed: bool, num: f32, token: &Token) -> String {
+    let num = render_int(signed, num);
+
+    match token {
+        Token::Number { .. } => format!("{}", num),
+        Token::Percentage { .. } => format!("{}%", num),
+        _ => panic!("render_number is not supposed to be called on a non-numerical token"),
+    }
+}
+
+fn render_int(signed: bool, num: f32) -> String {
     if signed {
         render_int_signed(num)
     } else {

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -27,10 +27,10 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
             unit,
         } => format!("{}{}", render_int(*signed, *num), unit),
         Token::WhiteSpace(_) => String::from(" "),
-        Token::Comment(comment) => format!("/* {} */", comment),
-        Token::Function(name) => format!("{}()", name),
-        Token::BadString(string) => format!("<Bad String {:?}>", string),
-        Token::BadUrl(url) => format!("<Bad URL {:?}>", url),
+        Token::Comment(comment) => format!("/* {} */", comment.clone()),
+        Token::Function(name) => format!("{}()", name.clone()),
+        Token::BadString(string) => format!("<Bad String {:?}>", string.clone()),
+        Token::BadUrl(url) => format!("<Bad URL {:?}>", url.clone()),
         // Single-character token
         sc_token => render_single_char_token(&sc_token),
     }

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -1,0 +1,95 @@
+use cssparser::Token;
+
+pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
+    // THIS TOOK FOREVER TO IMPLEMENT
+    // TODO: Make this easier to read, I guess
+
+    match token {
+        // TODO: Give these guys some better names
+        Token::Ident(ident) => format!("{}", ident.clone()),
+        Token::AtKeyword(value) => format!("@{}", value.clone()),
+        Token::Hash(name) | Token::IDHash(name) => format!("#{}", name.clone()),
+        Token::QuotedString(value) => format!("\"{}\"", value.clone()),
+        Token::Number {
+            has_sign: signed,
+            value: num,
+            int_value: _,
+        } => {
+            if *signed {
+                render_int_signed(*num)
+            } else {
+                render_int_unsigned(*num)
+            }
+        }
+        Token::Percentage {
+            has_sign: signed,
+            unit_value: num,
+            int_value: _,
+        } => {
+            format!(
+                "{}%",
+                if *signed {
+                    render_int_signed(*num)
+                } else {
+                    render_int_unsigned(*num)
+                }
+            )
+        }
+        Token::Dimension {
+            has_sign: signed,
+            value: num,
+            int_value: _,
+            unit,
+        } => {
+            format!(
+                "{}{}",
+                if *signed {
+                    render_int_signed(*num)
+                } else {
+                    render_int_unsigned(*num)
+                },
+                unit
+            )
+        }
+        Token::WhiteSpace(_) => String::from(" "),
+        Token::Comment(comment) => format!("/* {} */", comment),
+        Token::Function(name) => format!("{}()", name),
+        Token::BadString(string) => format!("<Bad String {:?}>", string),
+        Token::BadUrl(url) => format!("<Bad URL {:?}>", url),
+        // Single-character token
+        sc_token => String::from(match sc_token {
+            Token::Colon => ":",
+            Token::Semicolon => ";",
+            Token::Comma => ",",
+            Token::IncludeMatch => "~=",
+            Token::DashMatch => "|=",
+            Token::PrefixMatch => "^=",
+            Token::SuffixMatch => "$=",
+            Token::SubstringMatch => "*=",
+            Token::CDO => "<!--",
+            Token::CDC => "-->",
+            Token::ParenthesisBlock => "<(",
+            Token::SquareBracketBlock => "<[",
+            Token::CurlyBracketBlock => "<{",
+            Token::CloseParenthesis => "<)",
+            Token::CloseSquareBracket => "<]",
+            Token::CloseCurlyBracket => "<}",
+            other => panic!(
+                "Token {:?} is not supposed to match as a single-character token!",
+                other
+            ),
+        }),
+    }
+}
+
+fn render_int_signed(num: f32) -> String {
+    if num > 0.0 {
+        format!("+{}", num)
+    } else {
+        format!("-{}", num)
+    }
+}
+
+fn render_int_unsigned(num: f32) -> String {
+    format!("{}", num)
+}

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -64,7 +64,7 @@ fn render_number(signed: bool, num: f32, token: &Token) -> String {
     let num = render_int(signed, num);
 
     match token {
-        Token::Number { .. } => num.to_string(),
+        Token::Number { .. } => num,
         Token::Percentage { .. } => format!("{}%", num),
         _ => panic!("render_number is not supposed to be called on a non-numerical token"),
     }

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -32,29 +32,33 @@ pub(crate) fn render_token<'a>(token: &Token<'a>) -> String {
         Token::BadString(string) => format!("<Bad String {:?}>", string),
         Token::BadUrl(url) => format!("<Bad URL {:?}>", url),
         // Single-character token
-        sc_token => String::from(match sc_token {
-            Token::Colon => ":",
-            Token::Semicolon => ";",
-            Token::Comma => ",",
-            Token::IncludeMatch => "~=",
-            Token::DashMatch => "|=",
-            Token::PrefixMatch => "^=",
-            Token::SuffixMatch => "$=",
-            Token::SubstringMatch => "*=",
-            Token::CDO => "<!--",
-            Token::CDC => "-->",
-            Token::ParenthesisBlock => "<(",
-            Token::SquareBracketBlock => "<[",
-            Token::CurlyBracketBlock => "<{",
-            Token::CloseParenthesis => "<)",
-            Token::CloseSquareBracket => "<]",
-            Token::CloseCurlyBracket => "<}",
-            other => panic!(
-                "Token {:?} is not supposed to match as a single-character token!",
-                other
-            ),
-        }),
+        sc_token => render_single_char_token(&sc_token),
     }
+}
+
+fn render_single_char_token(token: &Token) -> String {
+    String::from(match token {
+        Token::Colon => ":",
+        Token::Semicolon => ";",
+        Token::Comma => ",",
+        Token::IncludeMatch => "~=",
+        Token::DashMatch => "|=",
+        Token::PrefixMatch => "^=",
+        Token::SuffixMatch => "$=",
+        Token::SubstringMatch => "*=",
+        Token::CDO => "<!--",
+        Token::CDC => "-->",
+        Token::ParenthesisBlock => "<(",
+        Token::SquareBracketBlock => "<[",
+        Token::CurlyBracketBlock => "<{",
+        Token::CloseParenthesis => "<)",
+        Token::CloseSquareBracket => "<]",
+        Token::CloseCurlyBracket => "<}",
+        other => panic!(
+            "Token {:?} is not supposed to match as a single-character token!",
+            other
+        ),
+    })
 }
 
 fn render_number(signed: bool, num: f32, token: &Token) -> String {

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -26,7 +26,7 @@ pub(crate) fn render_token(token: &Token<'_>) -> String {
             unit,
         } => format!("{}{}", render_int(*signed, *num), unit),
         Token::WhiteSpace(_) => String::from(" "),
-        Token::Comment(comment) => format!("/* {} */", &(*comment).clone()),
+        Token::Comment(comment) => format!("/* {} */", comment.clone()),
         Token::Function(name) => format!("{}()", name.clone()),
         Token::BadString(string) => format!("<Bad String {:?}>", string.clone()),
         Token::BadUrl(url) => format!("<Bad URL {:?}>", url.clone()),

--- a/src/error/utils.rs
+++ b/src/error/utils.rs
@@ -26,7 +26,7 @@ pub(crate) fn render_token(token: &Token<'_>) -> String {
             unit,
         } => format!("{}{}", render_int(*signed, *num), unit),
         Token::WhiteSpace(_) => String::from(" "),
-        Token::Comment(comment) => format!("/* {} */", comment.clone()),
+        Token::Comment(comment) => format!("/* {} */", comment),
         Token::Function(name) => format!("{}()", name.clone()),
         Token::BadString(string) => format!("<Bad String {:?}>", string.clone()),
         Token::BadUrl(url) => format!("<Bad URL {:?}>", url.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ pub use crate::node::Node;
 pub use crate::selector::Selector;
 
 pub mod element_ref;
+pub mod error;
 pub mod html;
 pub mod node;
 pub mod selector;

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -9,6 +9,7 @@ use html5ever::{LocalName, Namespace};
 use selectors::parser::SelectorParseErrorKind;
 use selectors::{matching, parser, visitor};
 
+use crate::error::SelectorErrorKind;
 use crate::ElementRef;
 
 /// Wrapper around CSS selectors.
@@ -23,12 +24,15 @@ pub struct Selector {
 impl Selector {
     /// Parses a CSS selector group.
 
-    pub fn parse(
-        selectors: &'_ str,
-    ) -> Result<Self, cssparser::ParseError<'_, SelectorParseErrorKind<'_>>> {
+    pub fn parse(selectors: &'_ str) -> Result<Self, SelectorErrorKind> {
         let mut parser_input = cssparser::ParserInput::new(selectors);
         let mut parser = cssparser::Parser::new(&mut parser_input);
-        parser::SelectorList::parse(&Parser, &mut parser).map(|list| Selector { selectors: list.0 })
+        match parser::SelectorList::parse(&Parser, &mut parser)
+            .map(|list| Selector { selectors: list.0 })
+        {
+            Ok(selected) => Ok(selected),
+            Err(err) => Err(SelectorErrorKind::from(err)),
+        }
     }
 
     /// Returns true if the element matches this selector.
@@ -140,7 +144,7 @@ impl cssparser::ToCss for PseudoElement {
 }
 
 impl<'i> TryFrom<&'i str> for Selector {
-    type Error = cssparser::ParseError<'i, SelectorParseErrorKind<'i>>;
+    type Error = SelectorErrorKind<'i>;
 
     fn try_from(s: &'i str) -> Result<Self, Self::Error> {
         Selector::parse(s)

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -30,7 +30,7 @@ impl Selector {
 
         parser::SelectorList::parse(&Parser, &mut parser)
             .map(|list| Selector { selectors: list.0 })
-            .map_err(|e| SelectorErrorKind::from(e))
+            .map_err(SelectorErrorKind::from)
     }
 
     /// Returns true if the element matches this selector.

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -27,12 +27,10 @@ impl Selector {
     pub fn parse(selectors: &'_ str) -> Result<Self, SelectorErrorKind> {
         let mut parser_input = cssparser::ParserInput::new(selectors);
         let mut parser = cssparser::Parser::new(&mut parser_input);
-        match parser::SelectorList::parse(&Parser, &mut parser)
+
+        parser::SelectorList::parse(&Parser, &mut parser)
             .map(|list| Selector { selectors: list.0 })
-        {
-            Ok(selected) => Ok(selected),
-            Err(err) => Err(SelectorErrorKind::from(err)),
-        }
+            .map_err(|e| SelectorErrorKind::from(e))
     }
 
     /// Returns true if the element matches this selector.


### PR DESCRIPTION
I might be adding different error types if needed, but for now the error type for `Selector::parse`'s `Result` is now a custom type that is exported.
This PR resolves #60
Improvements to the code are welcome