### PR TITLE
Re-export Element trait from selectors crate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -52,9 +52,7 @@ impl<'a> From<BasicParseErrorKind<'a>> for SelectorErrorKind<'a> {
         match err {
             BasicParseErrorKind::UnexpectedToken(token) => Self::UnexpectedToken(token),
             BasicParseErrorKind::EndOfInput => Self::EndOfLine,
-            BasicParseErrorKind::AtRuleInvalid(rule) => {
-                Self::InvalidAtRule(rule.clone().to_string())
-            }
+            BasicParseErrorKind::AtRuleInvalid(rule) => Self::InvalidAtRule(rule.to_string()),
             BasicParseErrorKind::AtRuleBodyInvalid => Self::InvalidAtRuleBody,
             BasicParseErrorKind::QualifiedRuleInvalid => Self::QualRuleInvalid,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ pub use crate::html::Html;
 pub use crate::node::Node;
 pub use crate::selector::Selector;
 
+pub use selectors::Element;
+
 pub mod element_ref;
 pub mod error;
 pub mod html;

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,8 @@
 //! HTML nodes.
 
-use std::collections::{hash_map, hash_set};
-use std::collections::{HashMap, HashSet};
+#[cfg(not(feature = "deterministic"))]
+use std::collections::{hash_map, HashMap};
+use std::collections::{hash_set, HashSet};
 use std::fmt;
 use std::ops::Deref;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,6 +12,9 @@ use html5ever::{Attribute, LocalName, QualName};
 use selectors::attr::CaseSensitivity;
 
 /// An HTML node.
+// `Element` is usally the most common variant and hence boxing it
+// will most likely not improve performance overall.
+#[allow(variant_size_differences)]
 #[derive(Clone, PartialEq, Eq)]
 pub enum Node {
     /// The document root.


### PR DESCRIPTION
This is required to use its methods like `parent_element` from a dependent crate without adding a direct dependency to `selectors` to that crate.