### PR TITLE
Bump cssparser to 0.28 and selectors to 0.23.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ repository = "https://github.com/causal-agent/scraper"
 readme = "README.md"
 
 [dependencies]
-cssparser = "0.27"
+cssparser = "0.28"
 ego-tree = "0.6.2"
 html5ever = "0.26"
 matches = "0.1.9"
-selectors = "0.22.0"
+selectors = "0.23.0"
 smallvec = "1.9.0"
 tendril = "0.4.3"
 indexmap = { version = "1.9.1", optional = true }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 
 use html5ever::{LocalName, Namespace};
 use selectors::parser::SelectorParseErrorKind;
-use selectors::{matching, parser, visitor};
+use selectors::{matching, parser};
 
 use crate::error::SelectorErrorKind;
 use crate::ElementRef;
@@ -67,21 +67,63 @@ impl<'i> parser::Parser<'i> for Parser {
 pub struct Simple;
 
 impl parser::SelectorImpl for Simple {
-    type AttrValue = String;
-    type Identifier = LocalName;
-    type ClassName = LocalName;
-    type PartName = LocalName;
-    type LocalName = LocalName;
-    type NamespacePrefix = LocalName;
+    type AttrValue = CssString;
+    type Identifier = CssLocalName;
+    type LocalName = CssLocalName;
+    type NamespacePrefix = CssLocalName;
     type NamespaceUrl = Namespace;
     type BorrowedNamespaceUrl = Namespace;
-    type BorrowedLocalName = LocalName;
+    type BorrowedLocalName = CssLocalName;
 
     type NonTSPseudoClass = NonTSPseudoClass;
     type PseudoElement = PseudoElement;
 
     // see: https://github.com/servo/servo/pull/19747#issuecomment-357106065
     type ExtraMatchingData = String;
+}
+
+/// Wraps [`String`] so that it can be used with [`selectors`]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CssString(pub String);
+
+impl<'a> From<&'a str> for CssString {
+    fn from(val: &'a str) -> Self {
+        Self(val.to_owned())
+    }
+}
+
+impl AsRef<str> for CssString {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl cssparser::ToCss for CssString {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        cssparser::serialize_string(&self.0, dest)
+    }
+}
+
+/// Wraps [`LocalName`] so that it can be used with [`selectors`]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct CssLocalName(pub LocalName);
+
+impl<'a> From<&'a str> for CssLocalName {
+    fn from(val: &'a str) -> Self {
+        Self(val.into())
+    }
+}
+
+impl cssparser::ToCss for CssLocalName {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        dest.write_str(&self.0)
+    }
 }
 
 /// Non Tree-Structural Pseudo-Class.
@@ -97,21 +139,6 @@ impl parser::NonTSPseudoClass for NonTSPseudoClass {
 
     fn is_user_action_state(&self) -> bool {
         false
-    }
-
-    fn has_zero_specificity(&self) -> bool {
-        false
-    }
-}
-
-impl parser::Visit for NonTSPseudoClass {
-    type Impl = Simple;
-
-    fn visit<V>(&self, _visitor: &mut V) -> bool
-    where
-        V: visitor::SelectorVisitor<Impl = Self::Impl>,
-    {
-        true
     }
 }
 


### PR DESCRIPTION
Minimal code changes to make the test suite pass, mostly wrapping String and LocalName so that the ToCss trait can be implemented for them.