### PR TITLE
RFC: Lazily fetch id and classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "html5ever",
  "indexmap",
  "matches",
+ "once_cell",
  "selectors",
  "smallvec",
  "tendril",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = "1.10.0"
 tendril = "0.4.3"
 ahash = "0.8"
 indexmap = { version = "1.9.2", optional = true }
+once_cell = "1.0"
 
 [dependencies.getopts]
 version = "0.2.21"

--- a/src/element_ref/element.rs
+++ b/src/element_ref/element.rs
@@ -106,8 +106,8 @@ impl<'a> Element for ElementRef<'a> {
     }
 
     fn has_id(&self, id: &CssLocalName, case_sensitivity: CaseSensitivity) -> bool {
-        match self.value().id {
-            Some(ref val) => case_sensitivity.eq(id.0.as_bytes(), val.as_bytes()),
+        match self.value().id() {
+            Some(val) => case_sensitivity.eq(id.0.as_bytes(), val.as_bytes()),
             None => false,
         }
     }


### PR DESCRIPTION
I think this might be a useful addition to #91 by avoiding the upfront costs for all elements and only materializing the set of classes when they are actually used.

This does come with an API change (no more public fields `id` and `classes`) and also a behavioural change, i.e. namespaced attributes `id` and `classes` would not be considered after this change.

(Honestly speaking, I am not sure whether there is a sensible namespace for these? `html`? So maybe a second lookup for `QualName::new(None, ns!(html), "id")` would suffice?)

((I added `once_cell` as a direct dependency but it already was part of the dependency closure.))