### PR TITLE
Re-export selectors' CaseSensitivity enum as it is part of our public API.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub use crate::html::Html;
 pub use crate::node::Node;
 pub use crate::selector::Selector;
 
-pub use selectors::Element;
+pub use selectors::{attr::CaseSensitivity, Element};
 
 pub mod element_ref;
 pub mod error;

--- a/src/node.rs
+++ b/src/node.rs
@@ -247,16 +247,13 @@ impl Element {
         let classes: HashSet<LocalName> = attrs
             .iter()
             .find(|a| a.name.local.deref() == "class")
-            .map_or_else(
-                || HashSet::new(),
-                |a| {
-                    a.value
-                        .deref()
-                        .split_whitespace()
-                        .map(LocalName::from)
-                        .collect()
-                },
-            );
+            .map_or_else(HashSet::new, |a| {
+                a.value
+                    .deref()
+                    .split_whitespace()
+                    .map(LocalName::from)
+                    .collect()
+            });
 
         Element {
             attrs: attrs.into_iter().map(|a| (a.name, a.value)).collect(),


### PR DESCRIPTION
Closes #105 