### PR TITLE
Use AHash instead of SipHash for storing attributes and classes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.8",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +520,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 name = "scraper"
 version = "0.15.0"
 dependencies = [
+ "ahash",
  "cssparser",
  "ego-tree",
  "getopts",
@@ -642,6 +655,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ matches = "0.1.10"
 selectors = "0.24.0"
 smallvec = "1.10.0"
 tendril = "0.4.3"
+ahash = "0.8"
 indexmap = { version = "1.9.2", optional = true }
 
 [dependencies.getopts]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,8 +1,11 @@
 //! HTML nodes.
 
 #[cfg(not(feature = "deterministic"))]
-use std::collections::{hash_map, HashMap};
-use std::collections::{hash_set, HashSet};
+use ahash::AHashMap as HashMap;
+use ahash::AHashSet as HashSet;
+#[cfg(not(feature = "deterministic"))]
+use std::collections::hash_map;
+use std::collections::hash_set;
 use std::fmt;
 use std::ops::Deref;
 


### PR DESCRIPTION
This has better performance while still being DoS resistant.

This PR is the hasher change broken out from #91 as that part has no interactions with #101 and appears straight forward enough.