### PR TITLE
Put collecting parser errors behind a default feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,11 @@ version = "0.2.21"
 optional = true
 
 [features]
-default = ["main"]
+default = ["main", "errors"]
 deterministic = ["indexmap"]
 main = ["getopts"]
 atomic = []
+errors = []
 
 [[bin]]
 name = "scraper"

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -1,5 +1,6 @@
 //! HTML documents and fragments.
 
+#[cfg(feature = "errors")]
 use std::borrow::Cow;
 
 use ego_tree::iter::Nodes;
@@ -21,6 +22,7 @@ use crate::{ElementRef, Node};
 /// Implements the `TreeSink` trait from the `html5ever` crate, which allows HTML to be parsed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Html {
+    #[cfg(feature = "errors")]
     /// Parse errors.
     pub errors: Vec<Cow<'static, str>>,
 
@@ -35,6 +37,7 @@ impl Html {
     /// Creates an empty HTML document.
     pub fn new_document() -> Self {
         Html {
+            #[cfg(feature = "errors")]
             errors: Vec::new(),
             quirks_mode: QuirksMode::NoQuirks,
             tree: Tree::new(Node::Document),
@@ -44,6 +47,7 @@ impl Html {
     /// Creates an empty HTML fragment.
     pub fn new_fragment() -> Self {
         Html {
+            #[cfg(feature = "errors")]
             errors: Vec::new(),
             quirks_mode: QuirksMode::NoQuirks,
             tree: Tree::new(Node::Fragment),

--- a/src/html/tree_sink.rs
+++ b/src/html/tree_sink.rs
@@ -19,7 +19,10 @@ impl TreeSink for Html {
 
     // Signal a parse error.
     fn parse_error(&mut self, msg: Cow<'static, str>) {
+        #[cfg(feature = "errors")]
         self.errors.push(msg);
+        #[cfg(not(feature = "errors"))]
+        let _ = msg;
     }
 
     // Set the document's quirks mode.


### PR DESCRIPTION
To be honest, I just noticed that the `errors` field actually exists and in my scraper code never looked at it so far. I am just extracting what I can. So it seems preferable to investing any (computational) effort into collecting them, at least if they are not desired. 