### PR TITLE
Make some minor improvements to the code base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-targets --all-features
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbe3c979c178231552ecba20214a8272df4e09f232a87aef4320cf06539aded"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "byteorder"
@@ -64,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dtoa-short"
@@ -101,9 +101,9 @@ checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "futf"
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
@@ -316,7 +316,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -351,18 +351,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -408,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
@@ -434,7 +434,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 2.3.2",
+ "bitflags 2.4.0",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 
 [[package]]
 name = "servo_arc"
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-width"
@@ -571,9 +571,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/examples/document.rs
+++ b/examples/document.rs
@@ -14,7 +14,7 @@ fn main() {
     stdin.read_line(&mut input).unwrap();
     let selector = Selector::parse(&input).unwrap();
 
-    write!(stdout, "HTML document:\n").unwrap();
+    writeln!(stdout, "HTML document:").unwrap();
     stdout.flush().unwrap();
     input.clear();
     stdin.read_to_string(&mut input).unwrap();

--- a/examples/fragment.rs
+++ b/examples/fragment.rs
@@ -14,7 +14,7 @@ fn main() {
     stdin.read_line(&mut input).unwrap();
     let selector = Selector::parse(&input).unwrap();
 
-    write!(stdout, "HTML fragment:\n").unwrap();
+    writeln!(stdout, "HTML fragment:").unwrap();
     stdout.flush().unwrap();
     input.clear();
     stdin.read_to_string(&mut input).unwrap();

--- a/src/element_ref/element.rs
+++ b/src/element_ref/element.rs
@@ -150,24 +150,18 @@ mod tests {
         let sel = Selector::parse("p").unwrap();
 
         let element = fragment.select(&sel).next().unwrap();
-        assert_eq!(
-            true,
-            element.has_id(
-                &CssLocalName::from("link_id_456"),
-                CaseSensitivity::CaseSensitive
-            )
-        );
+        assert!(element.has_id(
+            &CssLocalName::from("link_id_456"),
+            CaseSensitivity::CaseSensitive
+        ));
 
         let html = "<p>hey there</p>";
         let fragment = Html::parse_fragment(html);
         let element = fragment.select(&sel).next().unwrap();
-        assert_eq!(
-            false,
-            element.has_id(
-                &CssLocalName::from("any_link_id"),
-                CaseSensitivity::CaseSensitive
-            )
-        );
+        assert!(!element.has_id(
+            &CssLocalName::from("any_link_id"),
+            CaseSensitivity::CaseSensitive
+        ));
     }
 
     #[test]
@@ -176,13 +170,13 @@ mod tests {
         let fragment = Html::parse_fragment(html);
         let sel = Selector::parse("link").unwrap();
         let element = fragment.select(&sel).next().unwrap();
-        assert_eq!(true, element.is_link());
+        assert!(element.is_link());
 
         let html = "<p>hey there</p>";
         let fragment = Html::parse_fragment(html);
         let sel = Selector::parse("p").unwrap();
         let element = fragment.select(&sel).next().unwrap();
-        assert_eq!(false, element.is_link());
+        assert!(!element.is_link());
     }
 
     #[test]
@@ -191,24 +185,18 @@ mod tests {
         let fragment = Html::parse_fragment(html);
         let sel = Selector::parse("p").unwrap();
         let element = fragment.select(&sel).next().unwrap();
-        assert_eq!(
-            true,
-            element.has_class(
-                &CssLocalName::from("my_class"),
-                CaseSensitivity::CaseSensitive
-            )
-        );
+        assert!(element.has_class(
+            &CssLocalName::from("my_class"),
+            CaseSensitivity::CaseSensitive
+        ));
 
         let html = "<p>hey there</p>";
         let fragment = Html::parse_fragment(html);
         let sel = Selector::parse("p").unwrap();
         let element = fragment.select(&sel).next().unwrap();
-        assert_eq!(
-            false,
-            element.has_class(
-                &CssLocalName::from("my_class"),
-                CaseSensitivity::CaseSensitive
-            )
-        );
+        assert!(!element.has_class(
+            &CssLocalName::from("my_class"),
+            CaseSensitivity::CaseSensitive
+        ));
     }
 }

--- a/src/element_ref/mod.rs
+++ b/src/element_ref/mod.rs
@@ -70,6 +70,11 @@ impl<'a> ElementRef<'a> {
         self.serialize(TraversalScope::ChildrenOnly(None))
     }
 
+    /// Returns the value of an attribute.
+    pub fn attr(&self, attr: &str) -> Option<&str> {
+        self.value().attr(attr)
+    }
+
     /// Returns an iterator over descendent text nodes.
     pub fn text(&self) -> Text<'a> {
         Text {


### PR DESCRIPTION
- [x] Bump locked Cargo dependencies
- [x] Extend Clippy coverage to include all targets
- [x] Add `ElementRef::attr` forwarding method

Our code base is littered with calls to `element.value().attr("attribute")` and this little method would make this much more readable by shorting it to `element.attr("attribute")`.
    
Generally, I would also consider `impl Deref<Target=Element>` instead of `impl Deref<Target=NodeRef>` but that would be incompatible and more intrusive.