### PR TITLE
feat: support target `wasm32-unknown-unknown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ html5ever = "0.26"
 selectors = "0.25.0"
 smallvec = "1.11.0"
 tendril = "0.4.3"
-ahash = "0.8"
+ahash = { version = "0.8", default-features = false, features = ["std"] }
 indexmap = { version = "2.0.0", optional = true }
 once_cell = "1.0"
 


### PR DESCRIPTION
By deactivating default features on [`aHash`][1] which includes `getrandom` which is not being used in this crate and is not compatible with WASM.

Current Behavior:

If we attempt to compile using:

```bash
cargo build --target wasm32-unknown-unknown
```

We will get:

```
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/USER/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.10/src/lib.rs:285:9
    |
285 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
286 | |                         default, you may need to enable the \"js\" feature. \
287 | |                         For more information see: \
288 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /Users/USER/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.10/src/lib.rs:341:9
    |
341 |         imp::getrandom_inner(dest)?;
    |         ^^^ use of undeclared crate or module `imp`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

Alternatives:

Another approach would be providing a `js` feature for this use case

[1]: https://github.com/tkaitchuck/aHash/blob/f9acd508bd89e7c5b2877a9510098100f9018d64/Cargo.toml#L25-L31