### PR TITLE
feat: ToCss for Selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,6 @@ dependencies = [
  "indexmap",
  "once_cell",
  "selectors",
- "smallvec",
  "tendril",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ cssparser = "0.31.0"
 ego-tree = "0.6.2"
 html5ever = "0.26"
 selectors = "0.25.0"
-smallvec = "1.11.1"
 tendril = "0.4.3"
 ahash = "0.8"
 indexmap = { version = "2.0.2", optional = true }


### PR DESCRIPTION
I would like to use ToCss for the `Selector`. `Selector` is basically a wrapper of the `cssparser::SelectorList` which implements this trait too.

`SelectorList` is containing exactly the content of `Selector::selectors` but with redeclaring it and requiring the explicit dependency on `smallvec`. Changing this removes `smallvec` as a direct dependency. This should even have the same memory footprint as Rust optimizes the wrapper struct away.

Using `pub` for the `use ToCSS` is probably debatable but I think its a good thing to easily allow to use `to_css` and `to_css_string` without specifying the cssparser dependency explicitly and rather use `scraper::selector::ToCss` instead.