### PR TITLE
Fix lifetime in ElementRef::attr return value

### DIFF
--- a/src/element_ref/mod.rs
+++ b/src/element_ref/mod.rs
@@ -71,7 +71,7 @@ impl<'a> ElementRef<'a> {
     }
 
     /// Returns the value of an attribute.
-    pub fn attr(&self, attr: &str) -> Option<&str> {
+    pub fn attr(&self, attr: &str) -> Option<&'a str> {
         self.value().attr(attr)
     }
 


### PR DESCRIPTION
I tried to used the new accessor (from #140) on release and fixed a gotcha.

This allows returning references to the document when the traversal is done in an inner function.