### PR TITLE
Add trait to abstract over selectable collections of elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,15 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -28,15 +29,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -64,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -146,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "html5ever"
@@ -182,15 +183,15 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -246,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -316,7 +317,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -351,9 +352,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -399,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -433,7 +434,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cssparser",
  "derive_more",
  "fxhash",
@@ -448,22 +449,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -532,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -638,3 +639,23 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd66a62464e3ffd4e37bd09950c2b9dd6c4f8767380fabba0d523f9a775bc85a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "255c4596d41e6916ced49cfafea18727b24d67878fa180ddfd69b9df34fd1726"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]

--- a/src/element_ref/mod.rs
+++ b/src/element_ref/mod.rs
@@ -1,5 +1,6 @@
 //! Element references.
 
+use std::iter::FusedIterator;
 use std::ops::Deref;
 
 use ego_tree::iter::{Edge, Traverse};
@@ -114,6 +115,8 @@ impl<'a, 'b> Iterator for Select<'a, 'b> {
         None
     }
 }
+
+impl FusedIterator for Select<'_, '_> {}
 
 /// Iterator over descendent text nodes.
 #[derive(Debug, Clone)]

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "errors")]
 use std::borrow::Cow;
+use std::iter::FusedIterator;
 
 use ego_tree::iter::Nodes;
 use ego_tree::Tree;
@@ -160,6 +161,8 @@ impl<'a, 'b> DoubleEndedIterator for Select<'a, 'b> {
         None
     }
 }
+
+impl FusedIterator for Select<'_, '_> {}
 
 mod serializable;
 mod tree_sink;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub mod element_ref;
 pub mod error;
 pub mod html;
 pub mod node;
+pub mod selectable;
 pub mod selector;
 
 #[cfg(feature = "atomic")]

--- a/src/selectable.rs
+++ b/src/selectable.rs
@@ -1,0 +1,70 @@
+//! Provides the [`Selectable`] to abstract over collections of elements
+
+use crate::{
+    element_ref::{self, ElementRef},
+    html::{self, Html},
+    selector::Selector,
+};
+
+/// Trait to abstract over collections of elements to which a [CSS selector][Selector] can be applied
+///
+/// The mainly enables writing helper functions which are generic over [`Html`] and [`ElementRef`], e.g.
+///
+/// ```
+/// use scraper::{selectable::Selectable, selector::Selector};
+///
+/// fn text_of_first_match<'a, S>(selectable: S, selector: &Selector) -> Option<String>
+/// where
+///     S: Selectable<'a>,
+/// {
+///     selectable.select(selector).next().map(|element| element.text().collect())
+/// }
+/// ```
+pub trait Selectable<'a> {
+    /// Iterator over [element references][ElementRef] matching a [CSS selector[Selector]
+    type Select<'b>: Iterator<Item = ElementRef<'a>>;
+
+    /// Applies the given `selector` to the collection of elements represented by `self`
+    fn select(self, selector: &Selector) -> Self::Select<'_>;
+}
+
+impl<'a> Selectable<'a> for &'a Html {
+    type Select<'b> = html::Select<'a, 'b>;
+
+    fn select(self, selector: &Selector) -> Self::Select<'_> {
+        Html::select(self, selector)
+    }
+}
+
+impl<'a> Selectable<'a> for ElementRef<'a> {
+    type Select<'b> = element_ref::Select<'a, 'b>;
+
+    fn select(self, selector: &Selector) -> Self::Select<'_> {
+        ElementRef::select(&self, selector)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn select_one<'a, S>(selectable: S, selector: &Selector) -> Option<ElementRef<'a>>
+    where
+        S: Selectable<'a>,
+    {
+        selectable.select(selector).next()
+    }
+
+    #[test]
+    fn html_and_element_ref_are_selectable() {
+        let fragment = Html::parse_fragment(
+            r#"<select class="foo"><option value="bar">foobar</option></select>"#,
+        );
+
+        let selector = Selector::parse("select.foo").unwrap();
+        let element = select_one(&fragment, &selector).unwrap();
+
+        let selector = Selector::parse("select.foo option[value='bar']").unwrap();
+        let _element = select_one(element, &selector).unwrap();
+    }
+}


### PR DESCRIPTION
Our codebase contains a simpler version of this trait which we use to write helper functions which can be applied both at the top level to `Html` but also if selection is a multi-step process, i.e. to `ElementRef` itself, as the scope to which a CSS selector is applied.

Note that this uses generic associated type and hence requires Rust 1.65, c.f. <https://blog.rust-lang.org/2022/10/28/gats-stabilization.html>.