### PR TITLE
Select and Text are not fused iterators

### DIFF
--- a/src/element_ref/mod.rs
+++ b/src/element_ref/mod.rs
@@ -1,7 +1,6 @@
 //! Element references.
 
 use std::fmt;
-use std::iter::FusedIterator;
 use std::ops::Deref;
 
 use ego_tree::iter::{Edge, Traverse};
@@ -195,8 +194,6 @@ impl<'a> Iterator for Text<'a> {
         None
     }
 }
-
-impl FusedIterator for Text<'_> {}
 
 mod element;
 mod serializable;

--- a/src/element_ref/mod.rs
+++ b/src/element_ref/mod.rs
@@ -175,8 +175,6 @@ impl<'a, 'b> Iterator for Select<'a, 'b> {
     }
 }
 
-impl FusedIterator for Select<'_, '_> {}
-
 /// Iterator over descendent text nodes.
 #[derive(Debug, Clone)]
 pub struct Text<'a> {


### PR DESCRIPTION
```rust
use scraper::{Html, Selector};

const HTML: &str = r"
<div>
    <p>Hello</p>
    <p>World</p>
</div>
";

let html = Html::parse_fragment(HTML);
let selector = Selector::parse("div").unwrap();
let div = html.select(&selector).next().unwrap();
let selector = Selector::parse("p").unwrap();
let mut elements = div.select(&selector);
assert!(elements.next().is_some());
assert!(elements.next().is_some());
assert!(elements.next().is_none());
assert!(elements.next().is_some());
```